### PR TITLE
WIP: solidify start

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,7 @@
 	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 	"version": "0.2.0",
 	"configurations": [
+	
 		{
 			"type": "lldb",
 			"request": "launch",
@@ -15,9 +16,9 @@
 				]
 			},
 			"program": "target/debug/d4tools",
-			"env": {"RUST_LOG": "info"},
-			"args": ["create", "-g", "/tmp/1.g", "/tmp/1.bedgraph"],
-			"cwd": "/tmp"
+			"env": {"RUST_LOG": "info",  "RUST_BACKTRACE": "1"},
+			"args": ["view", "${workspaceFolder}/fdr.peaks.d4", "chr1:1-59999"],
+			"cwd": "${workspaceFolder}" 
 		},
 		{
 			"type": "lldb",

--- a/d4/src/ssio/reader.rs
+++ b/d4/src/ssio/reader.rs
@@ -131,8 +131,10 @@ impl<R: Read + Seek> D4TrackReader<R> {
             if table_ref.chrom_id == chrom_id {
                 let overlap_begin = table_ref.begin.max(begin);
                 let overlap_end = table_ref.end.min(end);
+
                 if overlap_begin < overlap_end {
-                    if overlap_begin == table_ref.begin || self.sfi.is_none() {
+                    //if overlap_begin + 1 == table_ref.begin || self.sfi.is_none() {
+                    if self.sfi.is_none() {
                         secondary_view.push(table_ref.clone());
                     } else {
                         let sfi = self.sfi.as_ref().unwrap();
@@ -147,6 +149,8 @@ impl<R: Read + Seek> D4TrackReader<R> {
                             ));
                         }
                     }
+                } else {
+                    break;
                 }
             }
         }

--- a/d4tools/src/show/main.rs
+++ b/d4tools/src/show/main.rs
@@ -56,9 +56,11 @@ fn parse_region_spec<T: Iterator<Item = String>>(
         for region_spec in regions {
             if let Some(captures) = region_pattern.captures(&region_spec) {
                 let chr = captures.name("CHR").unwrap().as_str();
-                let start: u32 = captures
+                // since we are reading a region like chr:start-end which is 1-based, we subtract 1 from the start.
+                let start: u32 = std::cmp::max(1, captures
                     .name("FROM")
-                    .map_or(0u32, |x| x.as_str().parse().unwrap_or(0));
+                    .map_or(0u32, |x| x.as_str().parse().unwrap_or(0))) - 1;
+
                 let end: u32 = captures
                     .name("TO")
                     .map_or_else(|| {


### PR DESCRIPTION
d4 uses region syntax like: chr1:1-100, which is generally 1-based such that this region would translate to `chr1\t0\t100` in BED format.
The internals of d4 are unclear, but I think this change is a start.

@38 could you have a look at the changes in ssio/reader.rs, the break might not work if things are not sorted (though they appear to be). The change of the if statement at line 136/137 is related to the +/- 1 used internally within d4 (which I don't yet understand).

This change passes all tests and fixes the problems seen in #59 