### PR TITLE
Infer type in bamfile

### DIFF
--- a/d4-hts/src/alignment/bamfile.rs
+++ b/d4-hts/src/alignment/bamfile.rs
@@ -99,7 +99,7 @@ impl BamFile {
         };
 
         for (size, raw_name) in sizes.iter().zip(raw_names) {
-            let raw_name = unsafe { CStr::from_ptr(*raw_name as *const i8) };
+            let raw_name = unsafe { CStr::from_ptr(*raw_name as *const u8) };
 
             ret.chrom_list
                 .push((raw_name.to_string_lossy().to_string(), *size as usize));

--- a/d4-hts/src/alignment/bamfile.rs
+++ b/d4-hts/src/alignment/bamfile.rs
@@ -99,7 +99,7 @@ impl BamFile {
         };
 
         for (size, raw_name) in sizes.iter().zip(raw_names) {
-            let raw_name = unsafe { CStr::from_ptr(*raw_name as *const u8) };
+            let raw_name = unsafe { CStr::from_ptr(*raw_name as *const _) };
 
             ret.chrom_list
                 .push((raw_name.to_string_lossy().to_string(), *size as usize));


### PR DESCRIPTION
There is an issue with libc on aarch64, in that it has c_char aliased to u8, whereas on amd64 libc uses i8 for c_char. The result of this is that pyd4 does not build correctly in docker containers on aarch64, verified on both Apple M1s and RPi4.

A solution to this appears be to let the compiler infer types in `bamfile.rs` L102, instead of specifying `i8`/`u8`.