### PR TITLE
hack ref_len -1

### DIFF
--- a/d4-hts/src/alignment/alignment_ext.rs
+++ b/d4-hts/src/alignment/alignment_ext.rs
@@ -17,7 +17,7 @@ impl<'a> Alignment<'a> {
     }
 
     pub fn ref_len(&self) -> usize {
-        self.cigar()
+        let length: usize = self.cigar()
             .filter_map(|x| {
                 if x.in_reference() {
                     Some(x.len as usize)
@@ -25,7 +25,8 @@ impl<'a> Alignment<'a> {
                     None
                 }
             })
-            .sum()
+            .sum();
+        length - 1
     }
 
     pub fn ref_end(&self) -> usize {


### PR DESCRIPTION
A naive fix to #75 .  I only use d4tools for its bam coverage and pyd4's numpy functionality, so this suits my purposes and will get unit tests on my end to pass.  I sort of doubt though this is the real solution and it doesn't have a negative impact in other parts of the software.  I just make the PR to bring more attention to this.