### PR TITLE
add -L to curl in build_htslib

### DIFF
--- a/d4-hts/build_htslib.sh
+++ b/d4-hts/build_htslib.sh
@@ -47,7 +47,7 @@ make libz.a
 cp libz.a ..
 cd ..
 
-curl http://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz | tar xz
+curl -L http://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz | tar xz
 cd bzip2-1.0.8
 is_musl && perl -i -pe 's/gcc/musl-gcc/g' Makefile
 is_musl || perl -i -pe 's/CFLAGS=/CFLAGS=-fPIC /g' Makefile


### PR DESCRIPTION
This should fix #74 as well as any other issues relating to build_htslib. I recently tried to use the d4 crate and encountered the same issue as in #74:

```
error: failed to run custom build command for `d4-hts v0.3.9`

Caused by:
  process didn't exit successfully: `/home/cade/create_cov_bed/target/debug/build/d4-hts-31bfd164fddf097c/build-script-build` (exit status: 101)
  --- stderr
  + pushd /home/cade/create_cov_bed/target/debug/build/d4-hts-3190b020235cc6ab/out
  + HTSLIB_VERSION=1.11
  + rm -rf /home/cade/create_cov_bed/target/debug/build/d4-hts-3190b020235cc6ab/out/htslib
  + git clone -b 1.11 http://github.com/samtools/htslib.git
  Cloning into 'htslib'...
  warning: redirecting to https://github.com/samtools/htslib.git/
  Note: switching to 'a7a90fe913f8a466f32f6e284cf46653944acd6f'.

  You are in 'detached HEAD' state. You can look around, make experimental
  changes and commit them, and you can discard any commits you make in this
  state without impacting any branches by switching back to a branch.

  If you want to create a new branch to retain commits you create, you may
  do so (now or later) by using -c with the switch command. Example:

    git switch -c <new-branch-name>

  Or undo this operation with:

    git switch -

  Turn off this advice by setting config variable advice.detachedHead to false

  + cd htslib
  + cat
  + perl -i -pe 's/hfile_libcurl\.o//g' Makefile
  + is_musl
  ++ echo x86_64-unknown-linux-gnu
  ++ grep musl
  + '[' '!' -z ']'
  + return 1
  + '[' x '!=' x ']'
  + curl -L http://github.com/madler/zlib/archive/refs/tags/v1.2.11.tar.gz
  + tar xz
    % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                   Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  629k    0  629k    0     0   515k      0 --:--:--  0:00:01 --:--:--  977k
  + cd zlib-1.2.11
  + is_musl
  ++ echo x86_64-unknown-linux-gnu
  ++ grep musl
  + '[' '!' -z ']'
  + return 1
  + ./configure
  + make libz.a
  + cp libz.a ..
  + cd ..
  + curl http://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz
  + tar xz
    % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                   Dload  Upload   Total   Spent    Left  Speed
100   235  100   235    0     0   1285      0 --:--:-- --:--:-- --:--:--  1291

  gzip: stdin: not in gzip format
  tar: Child returned status 1
  tar: Error is not recoverable: exiting now
  thread 'main' panicked at /home/cade/.cargo/registry/src/index.crates.io-6f17d22bba15001f/d4-hts-0.3.9/build.rs:34:5:
  assertion failed: Command::new("bash").args(&["build_htslib.sh",
                                          &version]).stdout(std::process::Stdio::null()).spawn().expect("Unable to build htslib").wait().unwrap().success()
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```