### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,18 @@
-FROM rust:1.50 as builder
-WORKDIR /usr/src/d4format
-COPY . .
+###########
+# BUILDER #
+###########
 
-RUN cargo build --release
+FROM rust:latest AS builder
 
-FROM debian:buster-slim
-RUN rm -rf /var/lib/apt/lists/*
-COPY --from=builder /usr/src/d4format/target/release/d4tools /usr/local/bin/d4tools
+RUN cargo install --git https://github.com/38/d4-format.git d4tools --branch master
+
+#########
+# FINAL #
+#########
+
+FROM debian:bookworm-slim
+
+# Import lib from builder
+COPY --from=builder /usr/local/cargo/bin/d4tools /usr/local/bin/d4tools
 
 CMD ["d4tools"]


### PR DESCRIPTION
Hello, I noticed that this bug is still not fixed. 

Here comes a suggestion for a fix! (fix #45 )


### Current master branch:

```
(base) chiararasi@n181-p119 d4-format % docker build -t d4tools .
[+] Building 29.9s (13/14)
 => [internal] load build definition from Dockerfile                                                                                                                                  0.1s
 => => transferring dockerfile: 290B                                                                                                                                                  0.1s
 => [internal] load .dockerignore                                                                                                                                                     0.1s
 => => transferring context: 2B                                                                                                                                                       0.0s
 => [internal] load metadata for docker.io/library/debian:buster-slim                                                                                                                 2.1s
 => [internal] load metadata for docker.io/library/rust:1.50                                                                                                                          2.2s
 => [auth] library/debian:pull token for registry-1.docker.io                                                                                                                         0.0s
 => [auth] library/rust:pull token for registry-1.docker.io                                                                                                                           0.0s
 => [builder 1/4] FROM docker.io/library/rust:1.50@sha256:25a32551f42722169ea0b50b9ea752bd43a31b3e52371e735ea675866e4eb164                                                           26.7s
 => => resolve docker.io/library/rust:1.50@sha256:25a32551f42722169ea0b50b9ea752bd43a31b3e52371e735ea675866e4eb164                                                                    0.0s
 => => sha256:a37b2a5ba365b9ad5a1b12ff924adb0c0cc27d994e076bbc488a91befb69bf0b 1.59kB / 1.59kB                                                                                        0.0s
 => => sha256:e22122b926a1a853d61887fa35c3fe53e05ee7dc0f2f488936dc9838bd0e230d 50.40MB / 50.40MB                                                                                      3.5s
 => => sha256:25a32551f42722169ea0b50b9ea752bd43a31b3e52371e735ea675866e4eb164 988B / 988B                                                                                            0.0s
 => => sha256:f29e09ae83733d697508e34827538cc0129b8719b85db943041c5d37287bcb81 7.83MB / 7.83MB                                                                                        1.9s
 => => sha256:e319e3daef68c36099bf3b534377a78d373f67bde3d156119c2463f5fe133ac5 10.00MB / 10.00MB                                                                                      4.0s
 => => sha256:943eccf74a61d958f9520fa58730b4246c1b28ae48347b9bb3347c4fc1b8baab 6.42kB / 6.42kB                                                                                        0.0s
 => => sha256:e499244fe254b6f980c82ea555f38e7a6527e5105545922005e88a6b81b01cac 51.84MB / 51.84MB                                                                                      8.6s
 => => sha256:5a6ebed20e89bafb5798e66484bd3f1bb41f6e8f6443d231f85b9b6eb2fec334 192.34MB / 192.34MB                                                                                   22.5s
 => => extracting sha256:e22122b926a1a853d61887fa35c3fe53e05ee7dc0f2f488936dc9838bd0e230d                                                                                             0.7s
 => => sha256:43e2d28cedcc0efdee2d199875e0dd291e1cb0720bb63b082d1e169a59782046 153.58MB / 153.58MB                                                                                   21.2s
 => => extracting sha256:f29e09ae83733d697508e34827538cc0129b8719b85db943041c5d37287bcb81                                                                                             0.1s
 => => extracting sha256:e319e3daef68c36099bf3b534377a78d373f67bde3d156119c2463f5fe133ac5                                                                                             0.1s
 => => extracting sha256:e499244fe254b6f980c82ea555f38e7a6527e5105545922005e88a6b81b01cac                                                                                             0.7s
 => => extracting sha256:5a6ebed20e89bafb5798e66484bd3f1bb41f6e8f6443d231f85b9b6eb2fec334                                                                                             2.1s
 => => extracting sha256:43e2d28cedcc0efdee2d199875e0dd291e1cb0720bb63b082d1e169a59782046                                                                                             1.7s
 => [internal] load build context                                                                                                                                                     0.1s
 => => transferring context: 7.00MB                                                                                                                                                   0.1s
 => [stage-1 1/3] FROM docker.io/library/debian:buster-slim@sha256:bb3dc79fddbca7e8903248ab916bb775c96ec61014b3d02b4f06043b604726dc                                                  14.4s
 => => resolve docker.io/library/debian:buster-slim@sha256:bb3dc79fddbca7e8903248ab916bb775c96ec61014b3d02b4f06043b604726dc                                                           0.0s
 => => sha256:bb3dc79fddbca7e8903248ab916bb775c96ec61014b3d02b4f06043b604726dc 984B / 984B                                                                                            0.0s
 => => sha256:32220ea48be72979c9f0810d69f3de9145c9584c2ee966c6ec26edbcf4640c0b 529B / 529B                                                                                            0.0s
 => => sha256:e1a7bb630c8baa947c5430a7f0965ef6afe71e88e90547aced2e601a89b68399 1.46kB / 1.46kB                                                                                        0.0s
 => => sha256:b338562f40a7fb7360dfae935da6d7e40d2545db18bc461d9d70ec1b2b657f33 27.34MB / 27.34MB                                                                                     13.9s
 => => extracting sha256:b338562f40a7fb7360dfae935da6d7e40d2545db18bc461d9d70ec1b2b657f33                                                                                             0.4s
 => [stage-1 2/3] RUN rm -rf /var/lib/apt/lists/*                                                                                                                                     0.5s
 => [builder 2/4] WORKDIR /usr/src/d4format                                                                                                                                           0.2s
 => [builder 3/4] COPY . .                                                                                                                                                            0.0s
 => ERROR [builder 4/4] RUN cargo build --release                                                                                                                                     0.5s
------
 > [builder 4/4] RUN cargo build --release:
#13 0.524 error: failed to parse manifest at `/usr/src/d4format/d4-framefile/Cargo.toml`
#13 0.524
#13 0.524 Caused by:
#13 0.524   failed to parse the `edition` key
#13 0.524
#13 0.524 Caused by:
#13 0.524   this version of Cargo is older than the `2021` edition, and only supports `2015` and `2018` editions.
------
executor failed running [/bin/sh -c cargo build --release]: exit code: 101
```

### This branch:

```
(base) chiararasi@n181-p119 d4-format % docker build -t d4tools .
[+] Building 124.7s (9/9) FINISHED
 => [internal] load build definition from Dockerfile                                                                  0.1s
 => => transferring dockerfile: 368B                                                                                  0.1s
 => [internal] load .dockerignore                                                                                     0.1s
 => => transferring context: 2B                                                                                       0.0s
 => [internal] load metadata for docker.io/library/debian:bookworm-slim                                               1.4s
 => [internal] load metadata for docker.io/library/rust:latest                                                        1.2s
 => [stage-1 1/2] FROM docker.io/library/debian:bookworm-slim@sha256:a629e796d77a7b2ff82186ed15d01a493801c020eed5ce6  5.9s
 => => resolve docker.io/library/debian:bookworm-slim@sha256:a629e796d77a7b2ff82186ed15d01a493801c020eed5ce6adaa2704  0.0s
 => => sha256:a629e796d77a7b2ff82186ed15d01a493801c020eed5ce6adaa2704356f15a1c 1.85kB / 1.85kB                        0.0s
 => => sha256:ace984fea4de21d4ad6d0047c3c6ab7ade9fcd9dee3e44c5fe6349d7dd063d86 529B / 529B                            0.0s
 => => sha256:4d3492ddbe3a7e0be3e4b21881792a4b576b6f3dcba3878d1c05a5daa3cea23b 1.48kB / 1.48kB                        0.0s
 => => sha256:92c3b3500be621c72c7ac6432a9d8f731f145f4a1535361ffd3a304e55f7ccda 29.16MB / 29.16MB                      5.3s
 => => extracting sha256:92c3b3500be621c72c7ac6432a9d8f731f145f4a1535361ffd3a304e55f7ccda                             0.5s
 => [builder 1/2] FROM docker.io/library/rust:latest@sha256:fcd390e0a3a6bfcf26969861efbe7b864df052aa71a361cf3cd7c5c  47.1s
 => => resolve docker.io/library/rust:latest@sha256:fcd390e0a3a6bfcf26969861efbe7b864df052aa71a361cf3cd7c5c585b1b413  0.0s
 => => sha256:fcd390e0a3a6bfcf26969861efbe7b864df052aa71a361cf3cd7c5c585b1b413 7.75kB / 7.75kB                        0.0s
 => => sha256:6a037b2ce4c2c40111ec33457322170c977bd58d9461371142baea4cdbd205ca 1.94kB / 1.94kB                        0.0s
 => => sha256:37568f77c6f527ba630906e5c17334822d18765ceba0c20bb62b6614b763c437 4.33kB / 4.33kB                        0.0s
 => => sha256:56c9b9253ff98351db158cb6789848656b8d54f411c0037347bf2358efb18f39 49.59MB / 49.59MB                      4.4s
 => => sha256:364d19f59f69474a80c53fc78da91f85553e16e8ba6a28063cbebf259821119e 23.59MB / 23.59MB                      4.7s
 => => extracting sha256:56c9b9253ff98351db158cb6789848656b8d54f411c0037347bf2358efb18f39                             0.7s
 => => sha256:843b1d8321825bc8302752ae003026f13bd15c6eef2efe032f3ca1520c5bbc07 64.00MB / 64.00MB                      8.1s
 => => sha256:a348c2a8d94613f34ce7d0ac4fd4e51800d8f4aa8a0bc9347fe5c8436b4c3bd5 202.65MB / 202.65MB                   27.6s
 => => extracting sha256:364d19f59f69474a80c53fc78da91f85553e16e8ba6a28063cbebf259821119e                             0.3s
 => => sha256:2dae49b7a70a18612523a29640ee13ce5fe3afbeaea13a1dc0e6e3f827dd5d64 248.53MB / 248.53MB                   43.6s
 => => extracting sha256:843b1d8321825bc8302752ae003026f13bd15c6eef2efe032f3ca1520c5bbc07                             1.0s
 => => extracting sha256:a348c2a8d94613f34ce7d0ac4fd4e51800d8f4aa8a0bc9347fe5c8436b4c3bd5                             2.4s
 => => extracting sha256:2dae49b7a70a18612523a29640ee13ce5fe3afbeaea13a1dc0e6e3f827dd5d64                             3.1s
 => [builder 2/2] RUN cargo install --git https://github.com/38/d4-format.git d4tools --branch master                75.5s
 => [stage-1 2/2] COPY --from=builder /usr/local/cargo/bin/d4tools /usr/local/bin/d4tools                             0.2s
 => exporting to image                                                                                                0.2s
 => => exporting layers                                                                                               0.2s
 => => writing image sha256:2bc2d9947230a8ae4d37607954e25326bb77c19e80287fd5420791da6b28e0c0                          0.0s
 => => naming to docker.io/library/d4tools                                                                            0.0s
(base) chiararasi@n181-p119 d4-format % docker run d4tools
D4 Utilities Program 0.3.10(D4 library version: 0.3.9)
Usage: d4tools <subcommand> <args>
Possible subcommands are:
	create   	Create a new D4 depth profile
	framedump	Dump The container data
	index    	Index related operations
	ls-track 	List all available tracks in the D4 file
	merge    	Merge existing D4 file as a multi-track D4 file
	plot     	Plot the specified region
	show     	Print the underlying depth profile
	stat     	Run statistics on the given file
	view     	Same as show

Type 'd4tools <subcommand> --help' to learn more about each subcommands.
(base) chiararasi@n181-p119 d4-format %
```

