### PR TITLE
Fix typo in build command in README.md

### DIFF
--- a/d4binding/README.md
+++ b/d4binding/README.md
@@ -6,7 +6,7 @@ To build the binding library, you can simple run the following command:
 
 ```shell
 # For release build
-cargo build --release --pakcage=d4binding
+cargo build --release --package=d4binding
 
 # For debug build
 cargo build --package=d4binding


### PR DESCRIPTION
Hi
I noticed a typo when I was trying to copy and paste the command from README.md and execute it.
Cheers!