### PR TITLE
Tentative fix to subtract with overflow error in perc_cov stat

### DIFF
--- a/d4/src/d4file/track.rs
+++ b/d4/src/d4file/track.rs
@@ -187,8 +187,6 @@ impl<P: PrimaryTableReader, S: SecondaryTableReader> MultiTrackPartitionReader
                 for (mut left, mut right, value) in iter {
                     left = left.max(part_left);
                     right = right.min(part_right).max(left);
-
-
                     for handle in active_handles.iter_mut() {
                         if last_right < left {
                             handle.feed_rows(last_right, left, &mut std::iter::once(default_value));
@@ -214,11 +212,9 @@ impl<P: PrimaryTableReader, S: SecondaryTableReader> MultiTrackPartitionReader
                     secondary: &mut self.secondary,
                     active_handles,
                 };
-
                 if part_left >= part_right {
                     return;
                 }    
-
                 decoder.decode_block(
                     part_left as usize,
                     (part_right - part_left) as usize,
@@ -226,7 +222,6 @@ impl<P: PrimaryTableReader, S: SecondaryTableReader> MultiTrackPartitionReader
                 );
             }
         });
-
     }
 
     fn chrom(&self) -> &str {

--- a/d4/src/d4file/track.rs
+++ b/d4/src/d4file/track.rs
@@ -179,11 +179,9 @@ impl<P: PrimaryTableReader, S: SecondaryTableReader> MultiTrackPartitionReader
         let mut decoder = self.primary.make_decoder();
 
         scan_partition_impl(handles, |part_left, part_right, active_handles| {
-
             if let Some(default_value) = default_primary_value {
                 let iter = self.secondary.seek_iter(part_left);
                 let mut last_right = part_left;
-
                 for (mut left, mut right, value) in iter {
                     left = left.max(part_left);
                     right = right.min(part_right).max(left);


### PR DESCRIPTION
Tentantive fix #88 

Tested locally with the following bed file:

```
18	29704840	29867058
18	29843485	30050447
18	29847463	30050395
18	29867839	29911633
```

### Master branch:

```
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.16s
     Running `target/debug/d4tools stat -s perc_cov=10,15,20,50,100 --region /Users/chiararasi/Documents/work/d4_data/intervals_garem1.bed /Users/chiararasi/Documents/work/d4_data/hg002.d4`
thread '<unnamed>' panicked at /Users/chiararasi/Documents/work/GITs/d4-format/d4/src/d4file/track.rs:215:21:
attempt to subtract with overflow
```


### This branch:

```
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.04s
     Running `target/debug/d4tools stat -s perc_cov=10,15,20,50,100 --region /Users/chiararasi/Documents/work/d4_data/intervals_garem1.bed /Users/chiararasi/Documents/work/d4_data/hg002.d4`
18	29704840	29867058	0.999	0.960	0.797	3.082e-4	0.000e0
18	29843485	30050447	0.999	0.973	0.832	2.271e-4	0.000e0
18	29847463	30050395	0.999	0.972	0.830	2.316e-4	0.000e0
18	29867839	29911633	1.000	0.972	0.833	0.000e0	0.000e0
```

If I try each single interval by itself on master branch -->
`18	29704840	29867058	0.999	0.960	0.797	3.082e-4	0.000e0`
`18	29843485	30050447	0.999	0.973	0.832	2.271e-4	0.000e0`
`18	29847463	30050395	0.999	0.972	0.830	2.316e-4	0.000e0`
`18	29867839	29911633	1.000	0.972	0.833	0.000e0	0.000e0`

