### PR TITLE
Fix --resolution option in `d4tools plot`

### DIFF
--- a/d4tools/src/plot/cli.yml
+++ b/d4tools/src/plot/cli.yml
@@ -14,6 +14,7 @@ args:
         short: R
         long: resolution
         help: Specify the resolution of the output image
+        value_name: widthxheight
     - region:
         required: true
         short: r


### PR DESCRIPTION
Hi

I have recently tried this tool again since the pull requests were merged.
It is very fast to create d4 format files using mosdepth.

I was using the plot subcommand of d4tools and noticed that the --resolution option is ignored. 

```sh
cargo build
 ./target/debug/d4tools plot --resolution 32x12 d4tools/test/data/input.d4 input.d4.svg --region 1
```

Actual output

```console
error: Found argument 'input.d4.svg' which wasn't expected, or isn't valid in this context

USAGE:
    plot <input-file> <output-file> --region <chr[:start[-end]]> --resolution

For more information try --help
```

Expected output

```
```

![input d4](https://github.com/user-attachments/assets/c9087392-2147-4fe6-a257-13a4a38b31c7)


I think the reason for this is that `value_name` is not specified and the option is set to take no arguments.

Thank you.